### PR TITLE
[FIX] Widht state of text wasn't saved when moving text element (#8)

### DIFF
--- a/app/components/MemeTextField/MemeTextField.js
+++ b/app/components/MemeTextField/MemeTextField.js
@@ -123,7 +123,7 @@ export default class MemeTextField extends Component {
             strokeTextBox.left = leftPos;
             strokeTextBox.bringToFront()
             fillTextBox.bringToFront();
-            this.styleBothLayers({ top: topPos, left: leftPos })
+            this.styleBothLayers({ top: topPos, left: leftPos, width: fillTextBox.width })
         })
 
         //on rotating


### PR DESCRIPTION
fixes #8 